### PR TITLE
Fix open Dependabot alerts: bump torch to 2.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy==1.22.0
 pandas==1.3.5
-torchvision==0.22.1
+torchvision==0.28.0
 scikit-learn==1.5.0
-torch==2.7.1
+torch==2.13.0
 tqdm==4.66.3
 transformers
 timm


### PR DESCRIPTION
## Summary
- Resolves both currently open Dependabot alerts on `torch` by bumping `torch` 2.7.1 → 2.13.0 and `torchvision` 0.22.1 → 0.28.0 (the pinned torch/torchvision versions must match; 0.28.0 requires `torch==2.13.0`).
- **Alert #18** (GHSA-rrmf-rvhw-rf47 / CVE-2025-3000, low severity): memory corruption in `torch.jit.script`. Advisory currently lists no patched version and covers `torch <= 2.12.0`, so any version above 2.12.0 clears it. This repo does not call `torch.jit.script`/TorchScript APIs (`grep -rn "torch.jit" .` finds no hits), so exposure was scanner-level, not an active code path.
- **Alert #12** (medium severity): improper resource shutdown/release, fixed in `torch==2.8.0`, covers `torch <= 2.7.1` — which is exactly the version PR #12 (`f72e955`) had set while fixing alert #18, re-introducing this one.
- The two alerts' vulnerable ranges overlap everywhere except `> 2.12.0`, so 2.13.0 is the lowest version that satisfies both.

## Test plan
- [x] Verified via `pip index`/PyPI metadata that `torchvision==0.28.0` requires exactly `torch==2.13.0`.
- [x] Confirmed no TorchScript (`torch.jit.script`/`.trace`) call sites exist in this repo.
- No test suite or CI is present in this repo to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)